### PR TITLE
Migrate to Junit5

### DIFF
--- a/buildSrc/src/main/kotlin/BuildDependenciesVersions.kt
+++ b/buildSrc/src/main/kotlin/BuildDependenciesVersions.kt
@@ -34,7 +34,7 @@ object BuildDependenciesVersions {
     const val TEST = "1.2.0"
     const val EXT = "1.1.1"
     const val ARCH_CORE = "2.1.0"
-    const val JUNIT = "4.13"
+    const val JUNIT = "5.6.2"
     const val ROBOELECTRIC = "4.3.1"
     const val MOCKITO = "2.2.0"
     const val MOCKK = "1.10.0"

--- a/buildSrc/src/main/kotlin/dependencies/TestDependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies/TestDependencies.kt
@@ -5,7 +5,7 @@ package dependencies
  * other library modules to build.
  */
 object TestDependencies {
-    const val JUNIT = "junit:junit:${BuildDependenciesVersions.JUNIT}"
+    const val JUNIT = "org.junit.jupiter:junit-jupiter-api:${BuildDependenciesVersions.JUNIT}"
     const val MOCKITO = "com.nhaarman.mockitokotlin2:mockito-kotlin:${BuildDependenciesVersions.MOCKITO}"
     const val MOCKK = "io.mockk:mockk:${BuildDependenciesVersions.MOCKK}"
     const val ASSERTJ = "org.assertj:assertj-core:${BuildDependenciesVersions.ASSERTJ}"

--- a/commons/ui/src/test/kotlin/com/jpaya/commons/ui/base/BaseViewHolderTest.kt
+++ b/commons/ui/src/test/kotlin/com/jpaya/commons/ui/base/BaseViewHolderTest.kt
@@ -2,12 +2,11 @@ package com.jpaya.commons.ui.base
 
 import android.view.View
 import androidx.databinding.ViewDataBinding
-import com.jpaya.commons.ui.base.BaseViewHolder
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class BaseViewHolderTest {
 

--- a/commons/ui/src/test/kotlin/com/jpaya/commons/ui/extensions/ContextExtensionsTest.kt
+++ b/commons/ui/src/test/kotlin/com/jpaya/commons/ui/extensions/ContextExtensionsTest.kt
@@ -4,16 +4,16 @@ import android.content.Context
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class ContextExtensionsTest {
 
     @MockK(relaxed = true)
     lateinit var context: Context
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/commons/ui/src/test/kotlin/com/jpaya/commons/ui/extensions/LifecycleOwnerExtensionsTest.kt
+++ b/commons/ui/src/test/kotlin/com/jpaya/commons/ui/extensions/LifecycleOwnerExtensionsTest.kt
@@ -1,30 +1,27 @@
 package com.jpaya.commons.ui.extensions
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.jpaya.commons.ui.extensions.observe
+import com.jpaya.libraries.testutils.lifecycle.TestLifecycleOwner
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
-import com.jpaya.libraries.testutils.lifecycle.TestLifecycleOwner
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.verify
 
+@ExtendWith(InstantExecutorExtension::class)
 class LifecycleOwnerExtensionsTest {
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
 
     private lateinit var lifecycleOwner: LifecycleOwner
 
-    @Before
+    @BeforeEach
     fun setUp() {
         lifecycleOwner = TestLifecycleOwner()
     }

--- a/commons/ui/src/test/kotlin/com/jpaya/commons/ui/livedata/SingleLiveDataTest.kt
+++ b/commons/ui/src/test/kotlin/com/jpaya/commons/ui/livedata/SingleLiveDataTest.kt
@@ -1,37 +1,31 @@
 package com.jpaya.commons.ui.livedata
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LifecycleOwner
 import com.jpaya.commons.ui.extensions.observe
+import com.jpaya.libraries.testutils.lifecycle.TestLifecycleOwner
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
-import com.jpaya.commons.ui.extensions.observe
-import com.jpaya.libraries.testutils.lifecycle.TestLifecycleOwner
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.*
 
+@ExtendWith(InstantExecutorExtension::class)
 class SingleLiveDataTest {
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
 
     private lateinit var lifecycleOwner: LifecycleOwner
 
-    @Before
+    @BeforeEach
     fun setUp() {
         lifecycleOwner = TestLifecycleOwner()
     }
 
     @Test
     fun observingSingleLiveData_WhenPostStringValue_ShouldTriggerOneEvent() {
-        val singleLiveData = com.jpaya.commons.ui.livedata.SingleLiveData<String>()
+        val singleLiveData = SingleLiveData<String>()
         val observerPostValue = "Event Value"
         val observer = mock<(String) -> Unit>()
         val observerCaptor = argumentCaptor<String>()
@@ -45,7 +39,7 @@ class SingleLiveDataTest {
 
     @Test
     fun observingSingleLiveData_WhenPostMultipleIntValue_ShouldTriggerMultipleTimes() {
-        val singleLiveData = com.jpaya.commons.ui.livedata.SingleLiveData<Int>()
+        val singleLiveData = SingleLiveData<Int>()
         val observerPostValue = 1
         val observer = mock<(Int) -> Unit>()
         val observerCaptor = argumentCaptor<Int>()
@@ -59,13 +53,13 @@ class SingleLiveDataTest {
 
         singleLiveData.postValue(observerPostValue)
 
-        Mockito.verify(observer, times(3)).invoke(observerCaptor.capture())
+        verify(observer, times(3)).invoke(observerCaptor.capture())
         assertEquals(observerPostValue, observerCaptor.lastValue)
     }
 
     @Test
     fun multipleObservingSingleLiveData_WhenPostIntValue_ShouldTriggerOnlyFirstObserver() {
-        val singleLiveData = com.jpaya.commons.ui.livedata.SingleLiveData<String>()
+        val singleLiveData = SingleLiveData<String>()
         val observerPostValue = "Event Value"
         val observer1 = mock<(String) -> Unit>()
         val observer2 = mock<(String) -> Unit>()
@@ -86,11 +80,11 @@ class SingleLiveDataTest {
 
     @Test
     fun observingSingleLiveData_WithoutPostValue_ShouldNotTrigger() {
-        val singleLiveData = com.jpaya.commons.ui.livedata.SingleLiveData<Int>()
+        val singleLiveData = SingleLiveData<Int>()
         val observer = mock<(Int) -> Unit>()
 
         lifecycleOwner.observe(singleLiveData, observer)
 
-        verify(observer, never()).invoke(Mockito.anyInt())
+        verify(observer, never()).invoke(anyInt())
     }
 }

--- a/commons/ui/src/test/kotlin/com/jpaya/commons/ui/recyckerview/RecyclerViewItemDecorationTest.kt
+++ b/commons/ui/src/test/kotlin/com/jpaya/commons/ui/recyckerview/RecyclerViewItemDecorationTest.kt
@@ -9,13 +9,13 @@ import com.jpaya.commons.ui.recyclerview.RecyclerViewItemDecoration
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class RecyclerViewItemDecorationTest {
 
-    lateinit var recyclerViewItemDecoration: RecyclerViewItemDecoration
+    private lateinit var recyclerViewItemDecoration: RecyclerViewItemDecoration
 
     @MockK(relaxed = true)
     lateinit var viewDecorate: View
@@ -28,7 +28,7 @@ class RecyclerViewItemDecorationTest {
     @MockK(relaxed = true)
     lateinit var linearLayoutManager: LinearLayoutManager
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/core/src/test/kotlin/com/jpaya/core/database/charactersfavorite/CharacterFavoriteRepositoryTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/database/charactersfavorite/CharacterFavoriteRepositoryTest.kt
@@ -1,14 +1,14 @@
 package com.jpaya.core.database.charactersfavorite
 
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.verify
 import com.jpaya.core.database.characterfavorite.CharacterFavorite
 import com.jpaya.core.database.characterfavorite.CharacterFavoriteDao
 import com.jpaya.core.database.characterfavorite.CharacterFavoriteRepository
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
@@ -16,9 +16,9 @@ class CharacterFavoriteRepositoryTest {
 
     @Mock
     lateinit var characterFavoriteDao: CharacterFavoriteDao
-    lateinit var characterFavoriteRepository: CharacterFavoriteRepository
+    private lateinit var characterFavoriteRepository: CharacterFavoriteRepository
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         characterFavoriteRepository =

--- a/core/src/test/kotlin/com/jpaya/core/database/charactersfavorite/CharacterFavoriteTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/database/charactersfavorite/CharacterFavoriteTest.kt
@@ -1,8 +1,8 @@
 package com.jpaya.core.database.charactersfavorite
 
 import com.jpaya.core.database.characterfavorite.CharacterFavorite
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterFavoriteTest {
 

--- a/core/src/test/kotlin/com/jpaya/core/database/migrations/MarvelDatabaseMigration1to2Test.kt
+++ b/core/src/test/kotlin/com/jpaya/core/database/migrations/MarvelDatabaseMigration1to2Test.kt
@@ -3,9 +3,9 @@ package com.jpaya.core.database.migrations
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
@@ -15,7 +15,7 @@ class MarvelDatabaseMigration1to2Test {
     lateinit var supportSQLiteDatabase: SupportSQLiteDatabase
     private val migration = MIGRATION_1_2
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockitoAnnotations.initMocks(this)
     }

--- a/core/src/test/kotlin/com/jpaya/core/di/ContextModuleTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/di/ContextModuleTest.kt
@@ -2,9 +2,9 @@ package com.jpaya.core.di
 
 import android.app.Application
 import com.jpaya.core.di.modules.ContextModule
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
@@ -14,7 +14,7 @@ class ContextModuleTest {
     lateinit var application: Application
     private lateinit var contextModule: ContextModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         contextModule = ContextModule(application)

--- a/core/src/test/kotlin/com/jpaya/core/di/DatabaseModuleTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/di/DatabaseModuleTest.kt
@@ -1,23 +1,23 @@
 package com.jpaya.core.di
 
 import android.content.Context
+import com.jpaya.core.database.MarvelDatabase
+import com.jpaya.core.database.characterfavorite.CharacterFavoriteDao
+import com.jpaya.core.di.modules.DatabaseModule
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.jpaya.core.database.MarvelDatabase
-import com.jpaya.core.database.characterfavorite.CharacterFavoriteDao
-import com.jpaya.core.di.modules.DatabaseModule
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DatabaseModuleTest {
 
     private lateinit var databaseModule: DatabaseModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         databaseModule = DatabaseModule()
     }

--- a/core/src/test/kotlin/com/jpaya/core/di/NetworkModuleTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/di/NetworkModuleTest.kt
@@ -1,25 +1,20 @@
 package com.jpaya.core.di
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import com.jpaya.core.BuildConfig
 import com.jpaya.core.di.modules.NetworkModule
 import com.jpaya.core.network.services.MarvelService
+import com.nhaarman.mockitokotlin2.*
 import okhttp3.logging.HttpLoggingInterceptor
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import retrofit2.Retrofit
 
 class NetworkModuleTest {
 
     private lateinit var networkModule: NetworkModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         networkModule = NetworkModule()
     }

--- a/core/src/test/kotlin/com/jpaya/core/extensions/ByteArrayExtensionsTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/extensions/ByteArrayExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.jpaya.core.extensions
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 /**
  * Unit test for ByteArrayExtensions functions

--- a/core/src/test/kotlin/com/jpaya/core/extensions/StringExtensionsTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/extensions/StringExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.jpaya.core.extensions
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 
 class StringExtensionsTest {
 

--- a/core/src/test/kotlin/com/jpaya/core/network/NetworkStateTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/NetworkStateTest.kt
@@ -1,8 +1,8 @@
 package com.jpaya.core.network
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class NetworkStateTest {
 

--- a/core/src/test/kotlin/com/jpaya/core/network/repositories/MarvelRepositoryTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/repositories/MarvelRepositoryTest.kt
@@ -1,32 +1,30 @@
 package com.jpaya.core.network.repositories
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.verify
 import com.jpaya.core.BuildConfig
 import com.jpaya.core.network.repositiories.MarvelRepository
 import com.jpaya.core.network.services.MarvelService
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
 private const val API_PUBLIC_KEY = BuildConfig.MARVEL_API_KEY_PUBLIC
 
+@ExtendWith(InstantExecutorExtension::class)
 class MarvelRepositoryTest {
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
 
     @Mock
     lateinit var marvelService: MarvelService
     private lateinit var marvelRepository: MarvelRepository
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockitoAnnotations.initMocks(this)
         marvelRepository = MarvelRepository(marvelService)

--- a/core/src/test/kotlin/com/jpaya/core/network/responses/BaseResponseTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/responses/BaseResponseTest.kt
@@ -1,9 +1,8 @@
 package com.jpaya.core.network.responses
 
-import com.jpaya.core.network.responses.DataResponse
 import com.nhaarman.mockitokotlin2.mock
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class BaseResponseTest {
 
@@ -21,9 +20,9 @@ class BaseResponseTest {
             data = data
         )
 
-        Assert.assertEquals(code, baseResponse.code)
-        Assert.assertEquals(status, baseResponse.status)
-        Assert.assertEquals(message, baseResponse.message)
-        Assert.assertEquals(data, baseResponse.data)
+        assertEquals(code, baseResponse.code)
+        assertEquals(status, baseResponse.status)
+        assertEquals(message, baseResponse.message)
+        assertEquals(data, baseResponse.data)
     }
 }

--- a/core/src/test/kotlin/com/jpaya/core/network/responses/CharacterResponseTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/responses/CharacterResponseTest.kt
@@ -1,10 +1,8 @@
 package com.jpaya.core.network.responses
 
-import com.jpaya.core.network.responses.CharacterResponse
-import com.jpaya.core.network.responses.CharacterThumbnailResponse
 import com.nhaarman.mockitokotlin2.mock
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterResponseTest {
 
@@ -23,9 +21,9 @@ class CharacterResponseTest {
                 thumbnail = thumbnail
             )
 
-        Assert.assertEquals(id, characterResponse.id)
-        Assert.assertEquals(name, characterResponse.name)
-        Assert.assertEquals(description, characterResponse.description)
-        Assert.assertEquals(thumbnail, characterResponse.thumbnail)
+        assertEquals(id, characterResponse.id)
+        assertEquals(name, characterResponse.name)
+        assertEquals(description, characterResponse.description)
+        assertEquals(thumbnail, characterResponse.thumbnail)
     }
 }

--- a/core/src/test/kotlin/com/jpaya/core/network/responses/CharacterThumbnailResponseTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/responses/CharacterThumbnailResponseTest.kt
@@ -1,8 +1,7 @@
 package com.jpaya.core.network.responses
 
-import com.jpaya.core.network.responses.CharacterThumbnailResponse
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterThumbnailResponseTest {
 
@@ -17,7 +16,7 @@ class CharacterThumbnailResponseTest {
                 extension = extension
             )
 
-        Assert.assertEquals(path, characterThumbnailResponse.path)
-        Assert.assertEquals(extension, characterThumbnailResponse.extension)
+        assertEquals(path, characterThumbnailResponse.path)
+        assertEquals(extension, characterThumbnailResponse.extension)
     }
 }

--- a/core/src/test/kotlin/com/jpaya/core/network/responses/DataResponseTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/responses/DataResponseTest.kt
@@ -1,9 +1,8 @@
 package com.jpaya.core.network.responses
 
-import com.jpaya.core.network.responses.DataResponse
 import com.nhaarman.mockitokotlin2.mock
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class DataResponseTest {
 
@@ -23,10 +22,10 @@ class DataResponseTest {
             results = results
         )
 
-        Assert.assertEquals(offset, dataResponse.offset)
-        Assert.assertEquals(limit, dataResponse.limit)
-        Assert.assertEquals(total, dataResponse.total)
-        Assert.assertEquals(count, dataResponse.count)
-        Assert.assertEquals(results, dataResponse.results)
+        assertEquals(offset, dataResponse.offset)
+        assertEquals(limit, dataResponse.limit)
+        assertEquals(total, dataResponse.total)
+        assertEquals(count, dataResponse.count)
+        assertEquals(results, dataResponse.results)
     }
 }

--- a/core/src/test/kotlin/com/jpaya/core/network/services/MarvelServiceTest.kt
+++ b/core/src/test/kotlin/com/jpaya/core/network/services/MarvelServiceTest.kt
@@ -1,9 +1,8 @@
 package com.jpaya.core.network.services
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.jpaya.core.network.responses.BaseResponse
 import com.jpaya.core.network.responses.CharacterResponse
-import kotlin.math.roundToInt
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -11,14 +10,15 @@ import okio.buffer
 import okio.source
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.instanceOf
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import kotlin.math.roundToInt
 
 object MockResponses {
     object GetCharacters {
@@ -34,15 +34,13 @@ object MockResponses {
     }
 }
 
+@ExtendWith(InstantExecutorExtension::class)
 class MarvelServiceTest {
-
-    @get:Rule
-    val rule = InstantTaskExecutorRule()
 
     private lateinit var service: MarvelService
     private lateinit var mockWebServer: MockWebServer
 
-    @Before
+    @BeforeEach
     fun setUp() {
         mockWebServer = MockWebServer()
         service = Retrofit.Builder()
@@ -52,7 +50,7 @@ class MarvelServiceTest {
             .create(MarvelService::class.java)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         mockWebServer.shutdown()
     }

--- a/features/abbreviations/src/test/kotlin/com/jpaya/dynamicfeatures/abbreviations/ExampleUnitTest.kt
+++ b/features/abbreviations/src/test/kotlin/com/jpaya/dynamicfeatures/abbreviations/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.jpaya.dynamicfeatures.abbreviations
 
-import org.junit.Test
-
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/features/abbreviations/src/test/kotlin/com/jpaya/dynamicfeatures/abbreviations/ui/AbbreviationsListViewStateTest.kt
+++ b/features/abbreviations/src/test/kotlin/com/jpaya/dynamicfeatures/abbreviations/ui/AbbreviationsListViewStateTest.kt
@@ -1,121 +1,122 @@
 package com.jpaya.dynamicfeatures.abbreviations.ui
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class AbbreviationsListViewStateTest {
 
-    lateinit var state: AbbreviationsListViewState
+    private lateinit var state: AbbreviationsListViewState
 
     @Test
     fun setStateAsRefreshing_ShouldBeSettled() {
         state = AbbreviationsListViewState.Refreshing
 
-        Assert.assertTrue(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsLoaded_ShouldBeSettled() {
         state = AbbreviationsListViewState.Loaded
 
-        Assert.assertTrue(state.isLoaded())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isLoaded())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsLoading_ShouldBeSettled() {
         state = AbbreviationsListViewState.Loading
 
-        Assert.assertTrue(state.isLoading())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isLoading())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsAddLoading_ShouldBeSettled() {
         state = AbbreviationsListViewState.AddLoading
 
-        Assert.assertTrue(state.isAddLoading())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isAddLoading())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsEmpty_ShouldBeSettled() {
         state = AbbreviationsListViewState.Empty
 
-        Assert.assertTrue(state.isEmpty())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isEmpty())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsError_ShouldBeSettled() {
         state = AbbreviationsListViewState.Error
 
-        Assert.assertTrue(state.isError())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isError())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsAddError_ShouldBeSettled() {
         state = AbbreviationsListViewState.AddError
 
-        Assert.assertTrue(state.isAddError())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isAddError())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsNoMoreElements_ShouldBeSettled() {
         state = AbbreviationsListViewState.NoMoreElements
 
-        Assert.assertTrue(state.isNoMoreElements())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
+        assertTrue(state.isNoMoreElements())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
     }
 }

--- a/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/CharactersFavoriteViewModelTest.kt
+++ b/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/CharactersFavoriteViewModelTest.kt
@@ -1,42 +1,34 @@
 package com.jpaya.dynamicfeatures.caractersfavorites.ui.favorite
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.jpaya.core.database.characterfavorite.CharacterFavorite
 import com.jpaya.core.database.characterfavorite.CharacterFavoriteRepository
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.CharactersFavoriteViewModel
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.CharactersFavoriteViewState
-import com.jpaya.libraries.testutils.rules.CoroutineRule
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
 import io.mockk.MockKAnnotations
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(InstantExecutorExtension::class)
 class CharactersFavoriteViewModelTest {
-
-    @ExperimentalCoroutinesApi
-    @get:Rule
-    var coroutinesTestRule = CoroutineRule()
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @MockK(relaxed = true)
     lateinit var repository: CharacterFavoriteRepository
     @MockK(relaxed = true)
     lateinit var stateObserver: Observer<CharactersFavoriteViewState>
-    lateinit var viewModel: CharactersFavoriteViewModel
+    private lateinit var viewModel: CharactersFavoriteViewModel
 
     private val data = MutableLiveData<List<CharacterFavorite>>()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
 

--- a/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/CharactersFavoriteViewStateTest.kt
+++ b/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/CharactersFavoriteViewStateTest.kt
@@ -1,26 +1,27 @@
 package com.jpaya.dynamicfeatures.caractersfavorites.ui.favorite
 
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.CharactersFavoriteViewState
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class CharactersFavoriteViewStateTest {
 
-    lateinit var state: CharactersFavoriteViewState
+    private lateinit var state: CharactersFavoriteViewState
 
     @Test
     fun setStateAsEmpty_ShouldBeSettled() {
         state = CharactersFavoriteViewState.Empty
 
-        Assert.assertTrue(state.isEmpty())
-        Assert.assertFalse(state.isListed())
+        assertTrue(state.isEmpty())
+        assertFalse(state.isListed())
     }
 
     @Test
     fun setStateAsListed_ShouldBeSettled() {
         state = CharactersFavoriteViewState.Listed
 
-        Assert.assertTrue(state.isListed())
-        Assert.assertFalse(state.isEmpty())
+        assertTrue(state.isListed())
+        assertFalse(state.isEmpty())
     }
 }

--- a/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/adapter/CharacterFavoriteViewHolderTest.kt
+++ b/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/adapter/CharacterFavoriteViewHolderTest.kt
@@ -1,58 +1,56 @@
 package com.jpaya.dynamicfeatures.caractersfavorites.ui.favorite.adapter
 
-// import android.view.LayoutInflater
-// import android.view.View
-// import androidx.databinding.ViewDataBinding
-// import com.jpaya.core.database.characterfavorite.CharacterFavorite
-// import com.jpaya.dynamicfeatures.charactersfavorites.databinding.ListItemCharactersFavoriteBinding
-// import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.adapter.holders.CharacterFavoriteViewHolder
-// import io.mockk.MockKAnnotations
-// import io.mockk.every
-// import io.mockk.impl.annotations.MockK
-// import io.mockk.mockk
-// import io.mockk.mockkStatic
-// import io.mockk.verify
-// import org.junit.Assert
-// import org.junit.Before
-// import org.junit.Test
-//
-// class CharacterFavoriteViewHolderTest {
-//
-//    @MockK
-//    lateinit var view: View
-//    @MockK
-//    lateinit var layoutInflater: LayoutInflater
-//    @MockK(relaxed = true)
-//    lateinit var binding: ListItemCharactersFavoriteBinding
-//    lateinit var viewHolder: CharacterFavoriteViewHolder
-//
-//    @Before
-//    fun setUp() {
-//        MockKAnnotations.init(this)
-//    }
-//
-//    @Test
-//    fun createViewHolder_ShouldInitializeCorrectly() {
-//        mockkStatic(ListItemCharactersFavoriteBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemCharactersFavoriteBinding.inflate(layoutInflater) } returns binding
-//
-//        viewHolder = CharacterFavoriteViewHolder(layoutInflater)
-//
-//        Assert.assertEquals(binding, viewHolder.binding)
-//    }
-//
-//    @Test
-//    fun bindViewHolder_ShouldBindingDataVariable() {
-//        mockkStatic(ListItemCharactersFavoriteBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemCharactersFavoriteBinding.inflate(layoutInflater) } returns binding
-//
-//        val characterFavorite = mockk<CharacterFavorite>()
-//        viewHolder = CharacterFavoriteViewHolder(layoutInflater)
-//        viewHolder.bind(characterFavorite)
-//
-//        verify { binding.character = characterFavorite }
-//        verify { binding.executePendingBindings() }
-//    }
-// }
+import android.view.LayoutInflater
+import android.view.View
+import androidx.databinding.ViewDataBinding
+import com.jpaya.core.database.characterfavorite.CharacterFavorite
+import com.jpaya.dynamicfeatures.charactersfavorites.databinding.ListItemCharactersFavoriteBinding
+import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.adapter.holders.CharacterFavoriteViewHolder
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CharacterFavoriteViewHolderTest {
+
+    @MockK
+    lateinit var view: View
+
+    @MockK
+    lateinit var layoutInflater: LayoutInflater
+
+    @MockK(relaxed = true)
+    lateinit var binding: ListItemCharactersFavoriteBinding
+    private lateinit var viewHolder: CharacterFavoriteViewHolder
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun createViewHolder_ShouldInitializeCorrectly() {
+        mockkStatic(ListItemCharactersFavoriteBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemCharactersFavoriteBinding.inflate(layoutInflater) } returns binding
+
+        viewHolder = CharacterFavoriteViewHolder(layoutInflater)
+
+        assertEquals(binding, viewHolder.binding)
+    }
+
+    @Test
+    fun bindViewHolder_ShouldBindingDataVariable() {
+        mockkStatic(ListItemCharactersFavoriteBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemCharactersFavoriteBinding.inflate(layoutInflater) } returns binding
+
+        val characterFavorite = mockk<CharacterFavorite>()
+        viewHolder = CharacterFavoriteViewHolder(layoutInflater)
+        viewHolder.bind(characterFavorite)
+
+        verify { binding.character = characterFavorite }
+        verify { binding.executePendingBindings() }
+    }
+}

--- a/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/adapter/CharactersFavoriteTouchHelperTest.kt
+++ b/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/adapter/CharactersFavoriteTouchHelperTest.kt
@@ -1,30 +1,23 @@
 package com.jpaya.dynamicfeatures.caractersfavorites.ui.favorite.adapter
 
-import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_IDLE
-import androidx.recyclerview.widget.ItemTouchHelper.LEFT
-import androidx.recyclerview.widget.ItemTouchHelper.RIGHT
+import androidx.recyclerview.widget.ItemTouchHelper.*
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.adapter.CharactersFavoriteTouchHelper
-import io.mockk.Called
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.verify
-import io.mockk.verifyAll
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CharactersFavoriteTouchHelperTest {
 
     @MockK(relaxed = true)
     lateinit var onSwiped: (Int) -> Unit
-    lateinit var touchHelper: CharactersFavoriteTouchHelper
+    private lateinit var touchHelper: CharactersFavoriteTouchHelper
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
         touchHelper = CharactersFavoriteTouchHelper(onSwiped)

--- a/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/di/CharactersFavoriteModuleTest.kt
+++ b/features/characters_favorites/src/test/kotlin/com/jpaya/dynamicfeatures/caractersfavorites/ui/favorite/di/CharactersFavoriteModuleTest.kt
@@ -6,25 +6,20 @@ import com.jpaya.core.database.characterfavorite.CharacterFavoriteRepository
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.CharactersFavoriteFragment
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.CharactersFavoriteViewModel
 import com.jpaya.dynamicfeatures.charactersfavorites.ui.favorite.di.CharactersFavoriteModule
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CharactersFavoriteModuleTest {
 
     @MockK
     lateinit var fragment: CharactersFavoriteFragment
-    lateinit var module: CharactersFavoriteModule
+    private lateinit var module: CharactersFavoriteModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/CharacterDetailViewModelTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/CharacterDetailViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.detail
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.jpaya.core.database.characterfavorite.CharacterFavoriteRepository
 import com.jpaya.core.network.repositiories.MarvelRepository
@@ -8,27 +7,16 @@ import com.jpaya.core.network.responses.BaseResponse
 import com.jpaya.core.network.responses.CharacterResponse
 import com.jpaya.dynamicfeatures.characterslist.ui.detail.model.CharacterDetail
 import com.jpaya.dynamicfeatures.characterslist.ui.detail.model.CharacterDetailMapper
-import com.jpaya.libraries.testutils.rules.CoroutineRule
-import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(InstantExecutorExtension::class)
 class CharacterDetailViewModelTest {
-
-    @ExperimentalCoroutinesApi
-    @get:Rule
-    var coroutinesTestRule = CoroutineRule()
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @MockK(relaxed = true)
     lateinit var marvelRepository: MarvelRepository
@@ -42,7 +30,7 @@ class CharacterDetailViewModelTest {
     lateinit var dataObserver: Observer<CharacterDetail>
     lateinit var viewModel: CharacterDetailViewModel
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
         viewModel = CharacterDetailViewModel(
@@ -66,7 +54,7 @@ class CharacterDetailViewModelTest {
         viewModel.loadCharacterDetail(1L)
 
         val expectedState: CharacterDetailViewState = CharacterDetailViewState.Error
-        Assert.assertEquals(expectedState, viewModel.state.value)
+        assertEquals(expectedState, viewModel.state.value)
         verify { stateObserver.onChanged(expectedState) }
     }
 
@@ -95,7 +83,7 @@ class CharacterDetailViewModelTest {
         viewModel.loadCharacterDetail(1L)
 
         val expectedState = CharacterDetailViewState.AddToFavorite
-        Assert.assertEquals(expectedState, viewModel.state.value)
+        assertEquals(expectedState, viewModel.state.value)
         verify { stateObserver.onChanged(expectedState) }
     }
 
@@ -109,7 +97,7 @@ class CharacterDetailViewModelTest {
         viewModel.loadCharacterDetail(1L)
 
         val expectedState = CharacterDetailViewState.AlreadyAddedToFavorite
-        Assert.assertEquals(expectedState, viewModel.state.value)
+        assertEquals(expectedState, viewModel.state.value)
         verify { stateObserver.onChanged(expectedState) }
     }
 
@@ -138,7 +126,7 @@ class CharacterDetailViewModelTest {
         viewModel.addCharacterToFavorite()
 
         val expectedState = CharacterDetailViewState.AddedToFavorite
-        Assert.assertEquals(expectedState, viewModel.state.value)
+        assertEquals(expectedState, viewModel.state.value)
         verify { stateObserver.onChanged(expectedState) }
         coVerify {
             characterFavoriteRepository.insertCharacterFavorite(
@@ -154,7 +142,7 @@ class CharacterDetailViewModelTest {
         viewModel.dismissCharacterDetail()
 
         val expectedState = CharacterDetailViewState.Dismiss
-        Assert.assertEquals(expectedState, viewModel.state.value)
+        assertEquals(expectedState, viewModel.state.value)
         verify { stateObserver.onChanged(expectedState) }
     }
 }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/CharacterDetailViewStateTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/CharacterDetailViewStateTest.kt
@@ -1,81 +1,82 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.detail
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class CharacterDetailViewStateTest {
 
-    lateinit var state: CharacterDetailViewState
+    private lateinit var state: CharacterDetailViewState
 
     @Test
     fun setStateAsLoading_ShouldBeSettled() {
         state = CharacterDetailViewState.Loading
 
-        Assert.assertTrue(state.isLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddToFavorite())
-        Assert.assertFalse(state.isAddedToFavorite())
-        Assert.assertFalse(state.isAlreadyAddedToFavorite())
-        Assert.assertFalse(state.isDismiss())
+        assertTrue(state.isLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddToFavorite())
+        assertFalse(state.isAddedToFavorite())
+        assertFalse(state.isAlreadyAddedToFavorite())
+        assertFalse(state.isDismiss())
     }
 
     @Test
     fun setStateAsError_ShouldBeSettled() {
         state = CharacterDetailViewState.Error
 
-        Assert.assertTrue(state.isError())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddToFavorite())
-        Assert.assertFalse(state.isAddedToFavorite())
-        Assert.assertFalse(state.isAlreadyAddedToFavorite())
-        Assert.assertFalse(state.isDismiss())
+        assertTrue(state.isError())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddToFavorite())
+        assertFalse(state.isAddedToFavorite())
+        assertFalse(state.isAlreadyAddedToFavorite())
+        assertFalse(state.isDismiss())
     }
 
     @Test
     fun setStateAsAddToFavorite_ShouldBeSettled() {
         state = CharacterDetailViewState.AddToFavorite
 
-        Assert.assertTrue(state.isAddToFavorite())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddedToFavorite())
-        Assert.assertFalse(state.isAlreadyAddedToFavorite())
-        Assert.assertFalse(state.isDismiss())
+        assertTrue(state.isAddToFavorite())
+        assertFalse(state.isLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddedToFavorite())
+        assertFalse(state.isAlreadyAddedToFavorite())
+        assertFalse(state.isDismiss())
     }
 
     @Test
     fun setStateAsAddedToFavorite_ShouldBeSettled() {
         state = CharacterDetailViewState.AddedToFavorite
 
-        Assert.assertTrue(state.isAddedToFavorite())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddToFavorite())
-        Assert.assertFalse(state.isAlreadyAddedToFavorite())
-        Assert.assertFalse(state.isDismiss())
+        assertTrue(state.isAddedToFavorite())
+        assertFalse(state.isLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddToFavorite())
+        assertFalse(state.isAlreadyAddedToFavorite())
+        assertFalse(state.isDismiss())
     }
 
     @Test
     fun setStateAsAlreadyAddedToFavorite_ShouldBeSettled() {
         state = CharacterDetailViewState.AlreadyAddedToFavorite
 
-        Assert.assertTrue(state.isAlreadyAddedToFavorite())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddToFavorite())
-        Assert.assertFalse(state.isAddedToFavorite())
-        Assert.assertFalse(state.isDismiss())
+        assertTrue(state.isAlreadyAddedToFavorite())
+        assertFalse(state.isLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddToFavorite())
+        assertFalse(state.isAddedToFavorite())
+        assertFalse(state.isDismiss())
     }
 
     @Test
     fun setStateAsDismiss_ShouldBeSettled() {
         state = CharacterDetailViewState.Dismiss
 
-        Assert.assertTrue(state.isDismiss())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddToFavorite())
-        Assert.assertFalse(state.isAddedToFavorite())
-        Assert.assertFalse(state.isAlreadyAddedToFavorite())
+        assertTrue(state.isDismiss())
+        assertFalse(state.isLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddToFavorite())
+        assertFalse(state.isAddedToFavorite())
+        assertFalse(state.isAlreadyAddedToFavorite())
     }
 }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/di/CharacterDetailModuleTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/di/CharacterDetailModuleTest.kt
@@ -7,16 +7,11 @@ import com.jpaya.core.network.repositiories.MarvelRepository
 import com.jpaya.dynamicfeatures.characterslist.ui.detail.CharacterDetailFragment
 import com.jpaya.dynamicfeatures.characterslist.ui.detail.CharacterDetailViewModel
 import com.jpaya.dynamicfeatures.characterslist.ui.detail.model.CharacterDetailMapper
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CharacterDetailModuleTest {
 
@@ -24,7 +19,7 @@ class CharacterDetailModuleTest {
     lateinit var fragment: CharacterDetailFragment
     lateinit var module: CharacterDetailModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/model/CharacterDetailMapperTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/model/CharacterDetailMapperTest.kt
@@ -5,30 +5,33 @@ import com.jpaya.core.network.responses.CharacterResponse
 import com.jpaya.core.network.responses.CharacterThumbnailResponse
 import com.jpaya.core.network.responses.DataResponse
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterDetailMapperTest {
 
     private val mapper = CharacterDetailMapper()
 
-    @Test(expected = NoSuchElementException::class)
+    @Test
     fun characterMapper_WithEmptyResults_ShouldThrowException() {
-        runBlocking {
-            val response = BaseResponse(
-                code = 200,
-                status = "Ok",
-                message = "Ok",
-                data = DataResponse<CharacterResponse>(
-                    offset = 0,
-                    limit = 0,
-                    total = 0,
-                    count = 0,
-                    results = emptyList()
+        Assertions.assertThrows(NoSuchElementException::class.java) {
+            runBlocking {
+                val response = BaseResponse(
+                    code = 200,
+                    status = "Ok",
+                    message = "Ok",
+                    data = DataResponse<CharacterResponse>(
+                        offset = 0,
+                        limit = 0,
+                        total = 0,
+                        count = 0,
+                        results = emptyList()
+                    )
                 )
-            )
 
-            mapper.map(response)
+                mapper.map(response)
+            }
         }
     }
 

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/model/CharacterDetailTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/detail/model/CharacterDetailTest.kt
@@ -1,7 +1,7 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.detail.model
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterDetailTest {
 
@@ -19,9 +19,9 @@ class CharacterDetailTest {
             imageUrl = imageUrl
         )
 
-        Assert.assertEquals(id, character.id)
-        Assert.assertEquals(name, character.name)
-        Assert.assertEquals(description, character.description)
-        Assert.assertEquals(imageUrl, character.imageUrl)
+        assertEquals(id, character.id)
+        assertEquals(name, character.name)
+        assertEquals(description, character.description)
+        assertEquals(imageUrl, character.imageUrl)
     }
 }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewEventTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewEventTest.kt
@@ -1,7 +1,7 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharactersListViewEventTest {
 

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewModelTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewModelTest.kt
@@ -1,31 +1,23 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.jpaya.core.network.NetworkState
 import com.jpaya.dynamicfeatures.characterslist.ui.list.paging.CharactersPageDataSource
 import com.jpaya.dynamicfeatures.characterslist.ui.list.paging.CharactersPageDataSourceFactory
-import com.jpaya.libraries.testutils.rules.CoroutineRule
+import com.jpaya.libraries.testutils.rules.InstantExecutorExtension
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(InstantExecutorExtension::class)
 class CharactersListViewModelTest {
-
-    @ExperimentalCoroutinesApi
-    @get:Rule
-    var coroutinesTestRule = CoroutineRule()
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @MockK(relaxed = true)
     lateinit var dataSourceFactory: CharactersPageDataSourceFactory
@@ -33,9 +25,9 @@ class CharactersListViewModelTest {
     lateinit var stateObserver: Observer<CharactersListViewState>
     @MockK(relaxed = true)
     lateinit var eventObserver: Observer<CharactersListViewEvent>
-    lateinit var viewModel: CharactersListViewModel
+    private lateinit var viewModel: CharactersListViewModel
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewStateTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/CharactersListViewStateTest.kt
@@ -1,7 +1,8 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
 
 class CharactersListViewStateTest {
 
@@ -11,111 +12,111 @@ class CharactersListViewStateTest {
     fun setStateAsRefreshing_ShouldBeSettled() {
         state = CharactersListViewState.Refreshing
 
-        Assert.assertTrue(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsLoaded_ShouldBeSettled() {
         state = CharactersListViewState.Loaded
 
-        Assert.assertTrue(state.isLoaded())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isLoaded())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsLoading_ShouldBeSettled() {
         state = CharactersListViewState.Loading
 
-        Assert.assertTrue(state.isLoading())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isLoading())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsAddLoading_ShouldBeSettled() {
         state = CharactersListViewState.AddLoading
 
-        Assert.assertTrue(state.isAddLoading())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isAddLoading())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsEmpty_ShouldBeSettled() {
         state = CharactersListViewState.Empty
 
-        Assert.assertTrue(state.isEmpty())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isEmpty())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsError_ShouldBeSettled() {
         state = CharactersListViewState.Error
 
-        Assert.assertTrue(state.isError())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isError())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsAddError_ShouldBeSettled() {
         state = CharactersListViewState.AddError
 
-        Assert.assertTrue(state.isAddError())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isNoMoreElements())
+        assertTrue(state.isAddError())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isNoMoreElements())
     }
 
     @Test
     fun setStateAsNoMoreElements_ShouldBeSettled() {
         state = CharactersListViewState.NoMoreElements
 
-        Assert.assertTrue(state.isNoMoreElements())
-        Assert.assertFalse(state.isRefreshing())
-        Assert.assertFalse(state.isLoaded())
-        Assert.assertFalse(state.isLoading())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isEmpty())
-        Assert.assertFalse(state.isError())
-        Assert.assertFalse(state.isAddError())
+        assertTrue(state.isNoMoreElements())
+        assertFalse(state.isRefreshing())
+        assertFalse(state.isLoaded())
+        assertFalse(state.isLoading())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isEmpty())
+        assertFalse(state.isError())
+        assertFalse(state.isAddError())
     }
 }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/CharactersListAdapterStateTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/CharactersListAdapterStateTest.kt
@@ -1,57 +1,58 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list.adapter
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class CharactersListAdapterStateTest {
 
-    lateinit var state: CharactersListAdapterState
+    private lateinit var state: CharactersListAdapterState
 
     @Test
     fun setStateAsAdded_ShouldBeSettled() {
         state = CharactersListAdapterState.Added
 
-        Assert.assertTrue(state.hasExtraRow)
-        Assert.assertTrue(state.isAdded())
+        assertTrue(state.hasExtraRow)
+        assertTrue(state.isAdded())
 
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMore())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMore())
     }
 
     @Test
     fun setStateAsAddLoading_ShouldBeSettled() {
         state = CharactersListAdapterState.AddLoading
 
-        Assert.assertTrue(state.hasExtraRow)
-        Assert.assertTrue(state.isAddLoading())
+        assertTrue(state.hasExtraRow)
+        assertTrue(state.isAddLoading())
 
-        Assert.assertFalse(state.isAdded())
-        Assert.assertFalse(state.isAddError())
-        Assert.assertFalse(state.isNoMore())
+        assertFalse(state.isAdded())
+        assertFalse(state.isAddError())
+        assertFalse(state.isNoMore())
     }
 
     @Test
     fun setStateAsAddError_ShouldBeSettled() {
         state = CharactersListAdapterState.AddError
 
-        Assert.assertTrue(state.hasExtraRow)
-        Assert.assertTrue(state.isAddError())
+        assertTrue(state.hasExtraRow)
+        assertTrue(state.isAddError())
 
-        Assert.assertFalse(state.isAdded())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isNoMore())
+        assertFalse(state.isAdded())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isNoMore())
     }
 
     @Test
     fun setStateAsNoMore_ShouldBeSettled() {
         state = CharactersListAdapterState.NoMore
 
-        Assert.assertFalse(state.hasExtraRow)
-        Assert.assertTrue(state.isNoMore())
+        assertFalse(state.hasExtraRow)
+        assertTrue(state.isNoMore())
 
-        Assert.assertFalse(state.isAdded())
-        Assert.assertFalse(state.isAddLoading())
-        Assert.assertFalse(state.isAddError())
+        assertFalse(state.isAdded())
+        assertFalse(state.isAddLoading())
+        assertFalse(state.isAddError())
     }
 }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/CharacterViewHolderTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/CharacterViewHolderTest.kt
@@ -1,61 +1,58 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders
 
-// import android.view.LayoutInflater
-// import android.view.View
-// import androidx.databinding.ViewDataBinding
-// import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemCharacterBinding
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListViewModel
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders.CharacterViewHolder
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.model.CharacterItem
-// import io.mockk.MockKAnnotations
-// import io.mockk.every
-// import io.mockk.impl.annotations.MockK
-// import io.mockk.mockk
-// import io.mockk.mockkStatic
-// import io.mockk.verify
-// import org.junit.Assert
-// import org.junit.Before
-// import org.junit.Test
-//
-// class CharacterViewHolderTest {
-//
-//    @MockK
-//    lateinit var view: View
-//    @MockK
-//    lateinit var layoutInflater: LayoutInflater
-//    @MockK(relaxed = true)
-//    lateinit var binding: ListItemCharacterBinding
-//    lateinit var viewHolder: CharacterViewHolder
-//
-//    @Before
-//    fun setUp() {
-//        MockKAnnotations.init(this)
-//    }
-//
-//    @Test
-//    fun createViewHolder_ShouldInitializeCorrectly() {
-//        mockkStatic(ListItemCharacterBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemCharacterBinding.inflate(layoutInflater) } returns binding
-//
-//        viewHolder = CharacterViewHolder(layoutInflater)
-//
-//        Assert.assertEquals(binding, viewHolder.binding)
-//    }
-//
-//    @Test
-//    fun bindViewHolder_ShouldBindingDataVariable() {
-//        mockkStatic(ListItemCharacterBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemCharacterBinding.inflate(layoutInflater) } returns binding
-//
-//        val viewModel = mockk<CharactersListViewModel>()
-//        val characterItem = mockk<CharacterItem>()
-//        viewHolder = CharacterViewHolder(layoutInflater)
-//        viewHolder.bind(viewModel, characterItem)
-//
-//        verify { binding.viewModel = viewModel }
-//        verify { binding.character = characterItem }
-//        verify { binding.executePendingBindings() }
-//    }
-// }
+import android.view.LayoutInflater
+import android.view.View
+import androidx.databinding.ViewDataBinding
+import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemCharacterBinding
+import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListViewModel
+import com.jpaya.dynamicfeatures.characterslist.ui.list.model.CharacterItem
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CharacterViewHolderTest {
+
+    @MockK
+    lateinit var view: View
+
+    @MockK
+    lateinit var layoutInflater: LayoutInflater
+
+    @MockK(relaxed = true)
+    lateinit var binding: ListItemCharacterBinding
+    lateinit var viewHolder: CharacterViewHolder
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun createViewHolder_ShouldInitializeCorrectly() {
+        mockkStatic(ListItemCharacterBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemCharacterBinding.inflate(layoutInflater) } returns binding
+
+        viewHolder = CharacterViewHolder(layoutInflater)
+
+        assertEquals(binding, viewHolder.binding)
+    }
+
+    @Test
+    fun bindViewHolder_ShouldBindingDataVariable() {
+        mockkStatic(ListItemCharacterBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemCharacterBinding.inflate(layoutInflater) } returns binding
+
+        val viewModel = mockk<CharactersListViewModel>()
+        val characterItem = mockk<CharacterItem>()
+        viewHolder = CharacterViewHolder(layoutInflater)
+        viewHolder.bind(viewModel, characterItem)
+
+        verify { binding.viewModel = viewModel }
+        verify { binding.character = characterItem }
+        verify { binding.executePendingBindings() }
+    }
+}

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/ErrorViewHolderTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/ErrorViewHolderTest.kt
@@ -1,58 +1,55 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders
 
-// import android.view.LayoutInflater
-// import android.view.View
-// import androidx.databinding.ViewDataBinding
-// import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemErrorBinding
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListViewModel
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders.ErrorViewHolder
-// import io.mockk.MockKAnnotations
-// import io.mockk.every
-// import io.mockk.impl.annotations.MockK
-// import io.mockk.mockk
-// import io.mockk.mockkStatic
-// import io.mockk.verify
-// import org.junit.Assert.assertEquals
-// import org.junit.Before
-// import org.junit.Test
-//
-// class ErrorViewHolderTest {
-//
-//    @MockK
-//    lateinit var view: View
-//    @MockK
-//    lateinit var layoutInflater: LayoutInflater
-//    @MockK(relaxed = true)
-//    lateinit var binding: ListItemErrorBinding
-//    lateinit var viewHolder: ErrorViewHolder
-//
-//    @Before
-//    fun setUp() {
-//        MockKAnnotations.init(this)
-//    }
-//
-//    @Test
-//    fun createViewHolder_ShouldInitializeCorrectly() {
-//        mockkStatic(ListItemErrorBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemErrorBinding.inflate(layoutInflater) } returns binding
-//
-//        viewHolder = ErrorViewHolder(layoutInflater)
-//
-//        assertEquals(binding, viewHolder.binding)
-//    }
-//
-//    @Test
-//    fun bindViewHolder_ShouldBindingDataVariable() {
-//        mockkStatic(ListItemErrorBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemErrorBinding.inflate(layoutInflater) } returns binding
-//
-//        val viewModel = mockk<CharactersListViewModel>()
-//        viewHolder = ErrorViewHolder(layoutInflater)
-//        viewHolder.bind(viewModel)
-//
-//        verify { binding.viewModel = viewModel }
-//        verify { binding.executePendingBindings() }
-//    }
-// }
+import android.view.LayoutInflater
+import android.view.View
+import androidx.databinding.ViewDataBinding
+import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemErrorBinding
+import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListViewModel
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ErrorViewHolderTest {
+
+    @MockK
+    lateinit var view: View
+
+    @MockK
+    lateinit var layoutInflater: LayoutInflater
+
+    @MockK(relaxed = true)
+    lateinit var binding: ListItemErrorBinding
+    private lateinit var viewHolder: ErrorViewHolder
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun createViewHolder_ShouldInitializeCorrectly() {
+        mockkStatic(ListItemErrorBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemErrorBinding.inflate(layoutInflater) } returns binding
+
+        viewHolder = ErrorViewHolder(layoutInflater)
+
+        assertEquals(binding, viewHolder.binding)
+    }
+
+    @Test
+    fun bindViewHolder_ShouldBindingDataVariable() {
+        mockkStatic(ListItemErrorBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemErrorBinding.inflate(layoutInflater) } returns binding
+
+        val viewModel = mockk<CharactersListViewModel>()
+        viewHolder = ErrorViewHolder(layoutInflater)
+        viewHolder.bind(viewModel)
+
+        verify { binding.viewModel = viewModel }
+        verify { binding.executePendingBindings() }
+    }
+}

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/LoadingViewHolderTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/adapter/holders/LoadingViewHolderTest.kt
@@ -1,41 +1,42 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders
 
-// import android.view.LayoutInflater
-// import android.view.View
-// import androidx.databinding.ViewDataBinding
-// import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemLoadingBinding
-// import com.jpaya.dynamicfeatures.characterslist.ui.list.adapter.holders.LoadingViewHolder
-// import io.mockk.MockKAnnotations
-// import io.mockk.every
-// import io.mockk.impl.annotations.MockK
-// import io.mockk.mockkStatic
-// import org.junit.Assert
-// import org.junit.Before
-// import org.junit.Test
-//
-// class LoadingViewHolderTest {
-//
-//    @MockK
-//    lateinit var view: View
-//    @MockK
-//    lateinit var layoutInflater: LayoutInflater
-//    @MockK(relaxed = true)
-//    lateinit var binding: ListItemLoadingBinding
-//    lateinit var viewHolder: LoadingViewHolder
-//
-//    @Before
-//    fun setUp() {
-//        MockKAnnotations.init(this)
-//    }
-//
-//    @Test
-//    fun createViewHolder_ShouldInitializeCorrectly() {
-//        mockkStatic(ListItemLoadingBinding::class)
-//        every { (binding as ViewDataBinding).root } returns view
-//        every { ListItemLoadingBinding.inflate(layoutInflater) } returns binding
-//
-//        viewHolder = LoadingViewHolder(layoutInflater)
-//
-//        Assert.assertEquals(binding, viewHolder.binding)
-//    }
-// }
+import android.view.LayoutInflater
+import android.view.View
+import androidx.databinding.ViewDataBinding
+import com.jpaya.dynamicfeatures.characterslist.databinding.ListItemLoadingBinding
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LoadingViewHolderTest {
+
+    @MockK
+    lateinit var view: View
+
+    @MockK
+    lateinit var layoutInflater: LayoutInflater
+
+    @MockK(relaxed = true)
+    lateinit var binding: ListItemLoadingBinding
+    lateinit var viewHolder: LoadingViewHolder
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun createViewHolder_ShouldInitializeCorrectly() {
+        mockkStatic(ListItemLoadingBinding::class)
+        every { (binding as ViewDataBinding).root } returns view
+        every { ListItemLoadingBinding.inflate(layoutInflater) } returns binding
+
+        viewHolder = LoadingViewHolder(layoutInflater)
+
+        assertEquals(binding, viewHolder.binding)
+    }
+}

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/di/CharactersListModuleTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/di/CharactersListModuleTest.kt
@@ -8,25 +8,20 @@ import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListFragment
 import com.jpaya.dynamicfeatures.characterslist.ui.list.CharactersListViewModel
 import com.jpaya.dynamicfeatures.characterslist.ui.list.model.CharacterItemMapper
 import com.jpaya.dynamicfeatures.characterslist.ui.list.paging.CharactersPageDataSourceFactory
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CharactersListModuleTest {
 
     @MockK
     lateinit var fragment: CharactersListFragment
-    lateinit var module: CharactersListModule
+    private lateinit var module: CharactersListModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/model/CharacterItemMapperTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/model/CharacterItemMapperTest.kt
@@ -5,9 +5,9 @@ import com.jpaya.core.network.responses.CharacterResponse
 import com.jpaya.core.network.responses.CharacterThumbnailResponse
 import com.jpaya.core.network.responses.DataResponse
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class CharacterItemMapperTest {
 

--- a/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/model/CharacterItemTest.kt
+++ b/features/characters_list/src/test/kotlin/com/jpaya/dynamicfeatures/characterslist/ui/list/model/CharacterItemTest.kt
@@ -1,7 +1,7 @@
 package com.jpaya.dynamicfeatures.characterslist.ui.list.model
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class CharacterItemTest {
 
@@ -19,9 +19,9 @@ class CharacterItemTest {
             imageUrl = imageUrl
         )
 
-        Assert.assertEquals(id, character.id)
-        Assert.assertEquals(name, character.name)
-        Assert.assertEquals(description, character.description)
-        Assert.assertEquals(imageUrl, character.imageUrl)
+        assertEquals(id, character.id)
+        assertEquals(name, character.name)
+        assertEquals(description, character.description)
+        assertEquals(imageUrl, character.imageUrl)
     }
 }

--- a/features/home/src/test/kotlin/com/jpaya/dynamicfeatures/home/ui/HomeViewStateTest.kt
+++ b/features/home/src/test/kotlin/com/jpaya/dynamicfeatures/home/ui/HomeViewStateTest.kt
@@ -1,12 +1,12 @@
 package com.jpaya.dynamicfeatures.home.ui
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class HomeViewStateTest {
 
-    lateinit var state: HomeViewState
+    private lateinit var state: HomeViewState
 
     @Test
     fun setStateAsFullScreen_ShouldBeSettled() {

--- a/features/home/src/test/kotlin/com/jpaya/dynamicfeatures/home/ui/di/HomeModuleTest.kt
+++ b/features/home/src/test/kotlin/com/jpaya/dynamicfeatures/home/ui/di/HomeModuleTest.kt
@@ -4,26 +4,21 @@ import androidx.lifecycle.ViewModel
 import com.jpaya.commons.ui.extensions.viewModel
 import com.jpaya.dynamicfeatures.home.ui.HomeFragment
 import com.jpaya.dynamicfeatures.home.ui.HomeViewModel
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.instanceOf
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class HomeModuleTest {
 
     @MockK
     lateinit var fragment: HomeFragment
-    lateinit var module: HomeModule
+    private lateinit var module: HomeModule
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
     }

--- a/libraries/test_utils/build.gradle.kts
+++ b/libraries/test_utils/build.gradle.kts
@@ -1,6 +1,7 @@
+
+import dependencies.AnnotationProcessorsDependencies
 import dependencies.Dependencies
 import dependencies.TestDependencies
-import dependencies.AnnotationProcessorsDependencies
 import extensions.implementation
 
 plugins {
@@ -11,6 +12,7 @@ dependencies {
     implementation(Dependencies.PAGING)
     implementation(Dependencies.NAVIGATION_UI)
 
+    implementation(TestDependencies.JUNIT)
     implementation(TestDependencies.MOCKITO)
     implementation(TestDependencies.ASSERTJ)
     implementation(TestDependencies.ROBOELECTRIC)

--- a/libraries/test_utils/src/main/kotlin/com/jpaya/libraries/testutils/rules/CoroutineExtension.kt
+++ b/libraries/test_utils/src/main/kotlin/com/jpaya/libraries/testutils/rules/CoroutineExtension.kt
@@ -1,0 +1,31 @@
+package com.jpaya.libraries.testutils.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * A JUnit Test Rule that swaps the background executor used by Coroutines with a
+ * different one which executes each task synchronously.
+ * <p>
+ * You can use this rule for your host side tests that use Coroutines.
+ */
+@ExperimentalCoroutinesApi
+class CoroutineExtension : BeforeEachCallback, AfterEachCallback {
+
+    private val dispatcher = TestCoroutineDispatcher()
+
+    override fun beforeEach(context: ExtensionContext?) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        Dispatchers.resetMain()
+        dispatcher.cleanupTestCoroutines()
+    }
+}

--- a/libraries/test_utils/src/main/kotlin/com/jpaya/libraries/testutils/rules/InstantExecutorExtension.kt
+++ b/libraries/test_utils/src/main/kotlin/com/jpaya/libraries/testutils/rules/InstantExecutorExtension.kt
@@ -1,0 +1,33 @@
+package com.jpaya.libraries.testutils.rules
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * A JUnit Test Rule that swaps the background executor used by the Architecture Components with a
+ * different one which executes each task synchronously.
+ * <p>
+ * You can use this rule for your host side tests that use Architecture Components.
+ */
+class InstantExecutorExtension : BeforeEachCallback, AfterEachCallback {
+
+    @SuppressLint("RestrictedApi")
+    override fun beforeEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(object : TaskExecutor() {
+            override fun executeOnDiskIO(runnable: Runnable) = runnable.run()
+
+            override fun postToMainThread(runnable: Runnable) = runnable.run()
+
+            override fun isMainThread(): Boolean = true
+        })
+    }
+
+    @SuppressLint("RestrictedApi")
+    override fun afterEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+}


### PR DESCRIPTION
Impossible to migrate all tests extending `RoboElectricTest` to Junit5 as Roboelectric does not support Junit5.