### PR TITLE
Replace APKs for App Bundles

### DIFF
--- a/.github/workflows/internal_release.yml
+++ b/.github/workflows/internal_release.yml
@@ -39,21 +39,21 @@ jobs:
           version_name="\"$latest_release\""
           sed -i "s/BuildAndroidConfig.VERSION_NAME/$version_name/g" app/build.gradle.kts
           sed -i "s/BuildAndroidConfig.VERSION_CODE/$VERSION_CODE/g" app/build.gradle.kts
-      - name: Build Signed APK
-        run: bash ./gradlew :app:assembleProdRelease
-      - name: Upload APK artifact
+      - name: Build Signed Bundle
+        run: bash ./gradlew :app:bundleProdRelease
+      - name: Upload Bundle artifact
         uses: actions/upload-artifact@v1
         with:
           name: app-release
-          path: app/build/outputs/apk/prod/release/app-prod-release.apk
+          path: app/build/outputs/bundle/prodRelease/app-prod-release.aab
 
-  uploadAPK:
-    name: Upload APK to Google Play
+  uploadBundle:
+    name: Upload Bundle to Google Play
     runs-on: ubuntu-latest
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - name: Download app APK
+      - name: Download app Bundle
         uses: actions/download-artifact@v1
         with:
           name: app-release
@@ -62,6 +62,6 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT }}
           packageName: com.jpaya.englishisfun
-          releaseFile: app-release/app-prod-release.apk
+          releaseFile: app-release/app-prod-release.aab
           track: internal
           whatsNewDirectory: whatsnew

--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -39,21 +39,21 @@ jobs:
           version_name="\"$latest_release\""
           sed -i "s/BuildAndroidConfig.VERSION_NAME/$version_name/g" app/build.gradle.kts
           sed -i "s/BuildAndroidConfig.VERSION_CODE/$VERSION_CODE/g" app/build.gradle.kts
-      - name: Build Build Signed APK
-        run: bash ./gradlew :app:assembleProdRelease
-      - name: Upload APK artifact
+      - name: Build Signed Bundle
+        run: bash ./gradlew :app:bundleProdRelease
+      - name: Upload Bundle artifact
         uses: actions/upload-artifact@v1
         with:
           name: app-release
-          path: app/build/outputs/apk/prod/release/app-prod-release.apk
+          path: app/build/outputs/bundle/prodRelease/app-prod-release.aab
 
-  uploadAPK:
-    name: Upload APK to Google Play
+  uploadBundle:
+    name: Upload Bundle to Google Play
     runs-on: ubuntu-latest
     needs: release
     steps:
       - uses: actions/checkout@v2
-      - name: Download app APK
+      - name: Download app Bundle
         uses: actions/download-artifact@v1
         with:
           name: app-release
@@ -62,6 +62,6 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT }}
           packageName: com.jpaya.englishisfun
-          releaseFile: app-release/app-prod-release.apk
+          releaseFile: app-release/app-prod-release.aab
           track: internal
           whatsNewDirectory: whatsnew


### PR DESCRIPTION
## Description

Update CD production and internal pipelines to generate and upload to Google Play an App Bundle instead of an APK.

Fixes #89

## Type of change

- [x] New feature (non-breaking change which adds a functionality)

## Checklist

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my changes work
- [ ] New and existing unit tests passed
