### PR TITLE
Remove onAttach method

### DIFF
--- a/base-android/src/main/kotlin/com/jpaya/base/ui/base/BaseFragment.kt
+++ b/base-android/src/main/kotlin/com/jpaya/base/ui/base/BaseFragment.kt
@@ -16,7 +16,6 @@
 
 package com.jpaya.base.ui.base
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View


### PR DESCRIPTION
## Description

Removed onAttach() method from BaseFragment class.

## Type of change

- [x] New feature (non-breaking change which adds a functionality)

## Checklist

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my changes work
- [x] New and existing unit tests passed
