### PR TITLE
Refactoring deprecated assertThat method

### DIFF
--- a/app/src/test/kotlin/com/jpaya/englishisfun/conditionals/ui/adapter/ConditionalsAdapterTest.kt
+++ b/app/src/test/kotlin/com/jpaya/englishisfun/conditionals/ui/adapter/ConditionalsAdapterTest.kt
@@ -21,7 +21,9 @@ import com.jpaya.englishisfun.conditionals.ui.model.ConditionalItem
 import com.jpaya.englishisfun.databinding.ConditionalsListItemBinding
 import com.jpaya.libraries.testutils.robolectric.TestRobolectric
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/jpaya/englishisfun/idioms/ui/adapter/IdiomsAdapterTest.kt
+++ b/app/src/test/kotlin/com/jpaya/englishisfun/idioms/ui/adapter/IdiomsAdapterTest.kt
@@ -21,7 +21,9 @@ import com.jpaya.englishisfun.databinding.IdiomsListItemBinding
 import com.jpaya.englishisfun.idioms.ui.model.IdiomItem
 import com.jpaya.libraries.testutils.robolectric.TestRobolectric
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/jpaya/englishisfun/irregulars/ui/adapter/IrregularsAdapterTest.kt
+++ b/app/src/test/kotlin/com/jpaya/englishisfun/irregulars/ui/adapter/IrregularsAdapterTest.kt
@@ -21,7 +21,9 @@ import com.jpaya.englishisfun.databinding.IrregularsListItemBinding
 import com.jpaya.englishisfun.irregulars.ui.model.IrregularItem
 import com.jpaya.libraries.testutils.robolectric.TestRobolectric
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/jpaya/englishisfun/phrasals/ui/adapter/PhrasalsAdapterTest.kt
+++ b/app/src/test/kotlin/com/jpaya/englishisfun/phrasals/ui/adapter/PhrasalsAdapterTest.kt
@@ -21,7 +21,9 @@ import com.jpaya.englishisfun.databinding.PhrasalsListItemBinding
 import com.jpaya.englishisfun.phrasals.ui.model.PhrasalItem
 import com.jpaya.libraries.testutils.robolectric.TestRobolectric
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/jpaya/englishisfun/statives/ui/adapter/StativesAdapterTest.kt
+++ b/app/src/test/kotlin/com/jpaya/englishisfun/statives/ui/adapter/StativesAdapterTest.kt
@@ -21,7 +21,9 @@ import com.jpaya.englishisfun.databinding.StativeListItemBinding
 import com.jpaya.englishisfun.statives.ui.model.StativeItem
 import com.jpaya.libraries.testutils.robolectric.TestRobolectric
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 


### PR DESCRIPTION
## Description

Refactoring deprecated assertThat method. Replaced for hamcrest method.

## Type of change

- [x] New feature (non-breaking change which adds a functionality)

## Checklist

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my changes work
- [x] New and existing unit tests passed
